### PR TITLE
chore: MSRV, 2021 edition, cleanup, clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,17 +13,17 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Markup Link Checker (mlc)
         uses: becheran/mlc@v0.16.0
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Markup Link Checker (mlc)
-      uses: becheran/mlc@v0.14.0
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Markup Link Checker (mlc)
+        uses: becheran/mlc@v0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,17 +2,18 @@
 name = "fast_hilbert"
 version = "2.0.1"
 authors = ["Armin <becherarmin@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Fast Hilbert 2D curve computation using an efficient Lookup Table (LUT)."
 keywords = [ "space-filling-curve", "hilbert", "peano-curves", "mapping", "algorithm" ]
 readme = "README.md"
 license = "MIT"
-categories = ["algorithms"]
+categories = ["algorithms", "science::geo"]
 repository = "https://github.com/becheran/fast-hilbert"
+rust-version = "1.80"
 
 [dev-dependencies]
 image = "0.25.6"
-criterion = "0.5.1"
+criterion = "0.6.0"
 hilbert = "0.1.2"
 hilbert_2d = "1.1.0"
 hilbert_curve = "0.2.0"
@@ -20,3 +21,13 @@ hilbert_curve = "0.2.0"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[lints.rust]
+unsafe_code = "forbid"
+unused_qualifications = "warn"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_sign_loss = "allow"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,6 +1,7 @@
 use core::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
 
+#[allow(clippy::too_many_lines)]
 fn criterion_benchmark(c: &mut Criterion) {
     let bits: usize = 8;
     let n: usize = 2usize.pow(bits as u32);
@@ -16,7 +17,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ));
                 }
             }
-        })
+        });
     });
 
     c.bench_function("hilbert_2d", |b| {
@@ -31,7 +32,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ));
                 }
             }
-        })
+        });
     });
 
     c.bench_function("hilbert", |b| {
@@ -42,7 +43,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(p.hilbert_transform(black_box(bits)));
                 }
             }
-        })
+        });
     });
 
     c.bench_function("fast_hilbert", |b| {
@@ -56,13 +57,13 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ));
                 }
             }
-        })
+        });
     });
 
     let xy_low: (u32, u32) = (1, 2);
     let xy_high: (u32, u32) = (u32::MAX - 1, u32::MAX - 2);
     let order: u8 = 32;
-    let n: usize = 2usize.pow(order as u32);
+    let n: usize = 2usize.pow(u32::from(order));
     c.bench_function("fast_hilbert_low", |b| {
         b.iter(|| {
             black_box(fast_hilbert::xy2h(
@@ -70,7 +71,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(xy_low.1),
                 black_box(order),
             ));
-        })
+        });
     });
     c.bench_function("fast_hilbert_high", |b| {
         b.iter(|| {
@@ -79,7 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 black_box(xy_high.1),
                 black_box(order),
             ));
-        })
+        });
     });
     c.bench_function("hilbert_curve_low", |b| {
         b.iter(|| {
@@ -88,7 +89,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 xy_low.1 as usize,
                 n,
             ));
-        })
+        });
     });
     c.bench_function("hilbert_curve_high", |b| {
         b.iter(|| {
@@ -97,7 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 xy_high.1 as usize,
                 n,
             ));
-        })
+        });
     });
     c.bench_function("hilbert_2d_low", |b| {
         b.iter(|| {
@@ -107,7 +108,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 order as usize,
                 hilbert_2d::Variant::Hilbert,
             ));
-        })
+        });
     });
     c.bench_function("hilbert_2d_high", |b| {
         b.iter(|| {
@@ -117,19 +118,19 @@ fn criterion_benchmark(c: &mut Criterion) {
                 order as usize,
                 hilbert_2d::Variant::Hilbert,
             ));
-        })
+        });
     });
     c.bench_function("hilbert_low", |b| {
         b.iter(|| {
             let p = hilbert::Point::new(0, &[xy_low.0, xy_low.1]);
             black_box(p.hilbert_transform(order as usize));
-        })
+        });
     });
     c.bench_function("hilbert_high", |b| {
         b.iter(|| {
             let p = hilbert::Point::new(0, &[xy_high.0, xy_high.1]);
             black_box(p.hilbert_transform(order as usize));
-        })
+        });
     });
 }
 criterion_group!(

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+avoid-breaking-exported-api = false


### PR DESCRIPTION
I did some basic cleanup using Clippy and other tools - nothing big :)

* Bump edition to 2021
* Add MSRV (I used `cargo msrv` to find it)
* Add rust and clippy lint settings to Cargo.toml, including pedantic
* format code a bit for readability (mostly suggested by clippy rules)
* update `criterion` to v0.6

If you like these, I can also add some common CI and release tooling to automate both validation and the release process of the crate. I use the same setup for many of my projects.